### PR TITLE
Mayor changes in utilities

### DIFF
--- a/logpar/cli/extract_parcellation.py
+++ b/logpar/cli/extract_parcellation.py
@@ -4,7 +4,7 @@ import logging
 import numpy
 from scipy.cluster.hierarchy import fcluster
 
-from ..utils import cifti_utils, dendrogram_utils
+from ..utils import cifti_utils, cifti_header, dendrogram_utils
 
 
 def check_input(outfile):
@@ -43,7 +43,6 @@ def extract_parcellation(dendrogram_file, nparcels, outfile):
         parcellation = fcluster(dendrogram, height, criterion='distance')
         parcellation_size = parcellation.max()
 
-        logging.debug('parcellation_size: {}'.format(parcellation_size))
         if parcellation_size == nparcels:
             break
 
@@ -51,8 +50,8 @@ def extract_parcellation(dendrogram_file, nparcels, outfile):
     if outfile.endswith('txt'):
         numpy.savetxt(outfile, parcellation, delimiter=',')
     else:
-        cifti_label_header = cifti_utils.label_header(xml_structures,
-                                                      nparcels)
+        cifti_label_header = cifti_header.create_label_header(xml_structures,
+                                                              nparcels)
 
         cifti_utils.save_cifti(outfile,
                                parcellation[None, None, None, None, None, ...],

--- a/logpar/utils/cifti_header.py
+++ b/logpar/utils/cifti_header.py
@@ -1,0 +1,143 @@
+''' Functions to operate with CIFTI HEADERS '''
+import os
+
+import numpy
+import nibabel
+
+import xml.etree.ElementTree as xml
+from logpar.utils import cifti_utils
+
+
+def header_intersection(header1, header2):
+    ''' Retrieves a new CIFTI header, which contains the structures
+        present in both input headers '''
+    xml_header = xml.fromstring(header2.extensions[0].get_content())
+
+    for dire in ['ROW', 'COLUMN']:
+        new_bmodels = cifti_utils.extract_brainmodel(header1, 'ALL', dire)
+        new_strucs = set(b.attrib['BrainStructure'] for b in new_bmodels)
+
+        new_parcels = cifti_utils.extract_parcel(header1, 'ALL', dire)
+        new_parcels = set(p.attrib['Name'] for p in new_parcels)
+
+        idx = 0 if dire == 'ROW' else 1
+        query = ".//MatrixIndicesMap[@AppliesToMatrixDimension='{}']".format(idx)
+        mimap = xml_header.find(query)
+        
+        # If this direction has labels, we keep only the labels present
+        # in both headers
+        parcels = mimap.findall('Parcels')
+        for parcel in parcels:
+            if parcel.attrib['Name'] not in new_parcels:
+                mimap.remove(parcel)  # Remove it
+        
+        # If the direction has BrainModels, we keep only the BM present
+        # in both headers. Moreover, we keep only the indices they share
+        bmodels = mimap.findall('BrainModel')
+        for bmodel in bmodels:
+            bstr = bmodel.attrib['BrainStructure']
+            btype = bmodel.attrib['ModelType']
+
+            if bstr not in new_strucs:
+                mimap.remove(bmodel)  # Not present: remove it
+
+            if cifti_utils.is_model_surf(btype):
+                # It's a surface, lets update its indices
+                _, new_vertices = cifti_utils.surface_attributes(header1, 
+                                                                 bstr,
+                                                                 dire)
+                _, vertices = cifti_utils.surface_attributes(header2,
+                                                             bstr, dire)
+                common = sorted(set(vertices).intersection(new_vertices))
+                common_txt = cifti_utils.indices2text(common)
+                bmodel.find('VertexIndices').text = common_txt
+                bmodel.attrib['IndexCount'] = str(len(common))
+            else:
+                # It's a volume, lets update its voxels
+                raise NotImplemented()
+        
+        # Finally, fix the attributes of each brain model
+        offset = 0
+        for bmodel in bmodels:
+            bmodel.attrib['IndexOffset'] = str(offset)
+            offset += int(bmodel.attrib['IndexCount'])
+
+        new_xml_string = xml.tostring(xml_header)
+        new_extension = nibabel.nifti1.Nifti1Extension(32, new_xml_string)
+        
+        header2.extensions[0] = new_extension
+
+        return header2
+
+
+def soft_colors_xml_label_map(nlabels):
+    ''' Returns an xml Element which represents a GiftiLabelTable
+        with soft colors
+
+        Parameters
+        ----------
+        nlabels: int
+            Number of colors to represent in the table
+
+        Returns
+        -------
+        xml Element
+            XML CIFTI LabelTable'''
+    named_map = xml.Element('NamedMap')
+    map_name = xml.SubElement(named_map, 'MapName')
+    map_name.text = 'Parcel'
+
+    label_table = xml.SubElement(named_map, 'LabelTable')
+    colors_path = os.path.dirname(os.path.abspath(__file__))
+    colors = numpy.loadtxt(os.path.join(colors_path, 'colors.txt'))
+    ncolors = len(colors)
+
+    background = xml.SubElement(label_table, 'Label',
+                                attrib={'Alpha':'0', 'Blue':'0', 'Red':'0',
+                                        'Green':'0', 'Key':'0'})
+    background.text = '???'
+
+    for key in range(1, nlabels+1):
+        red, green, blue = colors[(key-1)%ncolors]
+        if red == green and green == blue:
+            # remove this gray
+            red, blue = 0.7*red, 0.95*blue
+        label = xml.SubElement(label_table, 'Label',
+                               attrib={'Alpha':'1', 'Blue':str(blue),
+                                       'Red':str(red), 'Green':str(green),
+                                       'Key':str(key)})
+        label.text = str(key)
+    return named_map
+
+
+def create_label_header(xml_structures, nparcels):
+    ''' Creates a label header for different structures. Right now this is
+        a draft. TODO: Extend to work with many structures at the same time '''
+    cifti_extension = xml.Element('CIFTI', {'Version': '2'})
+
+    matrix = xml.SubElement(cifti_extension, 'Matrix')
+
+    LABELS = 'CIFTI_INDEX_TYPE_LABELS'
+    BRAIN_MODEL = 'CIFTI_INDEX_TYPE_BRAIN_MODELS'
+
+    # First dimention: LABEL
+    mat_indx_map_0 = xml.SubElement(matrix, 'MatrixIndicesMap',
+                                    {'AppliesToMatrixDimension': '0',
+                                     'IndicesMapToDataType': LABELS})
+
+    mat_indx_map_0.insert(0, soft_colors_xml_label_map(nparcels))
+
+    # Second dimention: what the columns represents.
+    mat_indx_map_1 = xml.SubElement(matrix, 'MatrixIndicesMap',
+                                    {'AppliesToMatrixDimension': '1',
+                                     'IndicesMapToDataType': BRAIN_MODEL})
+
+    for i, structure in enumerate(xml_structures):
+        mat_indx_map_1.insert(i, structure)
+
+    cifti_header = nibabel.nifti2.Nifti2Header()
+
+    cifti_header.extensions.append(
+        nibabel.nifti1.Nifti1Extension(32, xml.tostring(cifti_extension)))
+
+    return cifti_header

--- a/logpar/utils/tests/test_cifti_header.py
+++ b/logpar/utils/tests/test_cifti_header.py
@@ -1,0 +1,33 @@
+''' Test cifti_utils.py '''
+import xml.etree.ElementTree as xml
+
+import nibabel
+import numpy
+
+from .. import cifti_header, cifti_utils
+
+
+def test_label_color():
+    ''' Tests that a correct LabelTable is created '''
+
+    cifti_test = nibabel.load('./logpar/cli/tests/data/test.dconn.nii')
+    nlabels = 10
+
+    header = cifti_test.header
+
+    xml_structures = cifti_utils.extract_brainmodel(header, 'ALL', 'COLUMN')
+
+    lt_header = cifti_header.create_label_header(xml_structures, 10)
+
+    xml_in_labeltable = cifti_utils.extract_brainmodel(lt_header, 'ALL',
+                                                       'COLUMN')
+
+    for original, retrieved in zip(xml_structures, xml_in_labeltable):
+        numpy.testing.assert_equal(original.attrib['BrainStructure'],
+                                   retrieved.attrib['BrainStructure'])
+
+    extension_xml = xml.fromstring(lt_header.extensions[0].get_content())
+    labels = extension_xml.findall('.//Label')
+    
+    # Number of labels + '???'background
+    numpy.testing.assert_equal(len(labels), nlabels+1)

--- a/logpar/utils/tests/test_cifti_utils.py
+++ b/logpar/utils/tests/test_cifti_utils.py
@@ -69,32 +69,6 @@ def test_extract_all_xml_structure():
                                    bmodel)
 
 
-def test_label_color():
-    ''' Tests that a correct LabelTable is created '''
-
-    cifti_test = nibabel.load('./logpar/cli/tests/data/test.dconn.nii')
-    nlabels = 10
-
-    header = cifti_test.header
-
-    xml_structures = cifti_utils.extract_brainmodel(header, 'ALL', 'COLUMN')
-
-    lt_header = cifti_utils.label_header(xml_structures, 10)
-
-    xml_in_labeltable = cifti_utils.extract_brainmodel(lt_header, 'ALL',
-                                                       'COLUMN')
-
-    for original, retrieved in zip(xml_structures, xml_in_labeltable):
-        numpy.testing.assert_equal(original.attrib['BrainStructure'],
-                                   retrieved.attrib['BrainStructure'])
-
-    extension_xml = xml.fromstring(lt_header.extensions[0].get_content())
-    labels = extension_xml.findall('.//Label')
-    
-    # Number of labels + '???'background
-    numpy.testing.assert_equal(len(labels), nlabels+1)
-
-
 def test_constraint_matrix():
     ''' Test that the constraint matrix is correctly generated '''
     surf_left = gifti.read('./logpar/cli/tests/data/L.white.surf.gii')


### PR DESCRIPTION
Cifti_utils was splited in cifti_utils and cifti_header, this will
allow to separate the functionality of those scripts (one to manipulate
cifti structures in general, the other to create cifti headers). The
script other_utils was removed. The tests were modified to reflect
the changes in the utilities.